### PR TITLE
Ignore help tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.tap
 doc/*.description
 doc/*.install
+doc/tags


### PR DESCRIPTION
Adds `doc/tags` to `.gitignore` to suppress the "untracked content" message after running `:helptags` when this repository is a submodule.